### PR TITLE
Fix logging in glinet custom script

### DIFF
--- a/glinet/99-custom.sh
+++ b/glinet/99-custom.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 # 该脚本为immortalwrt首次启动时 运行的脚本 即 /etc/uci-defaults/99-custom.sh
+# 日志文件路径
+LOGFILE="/tmp/uci-defaults-log.txt"
+echo "Starting 99-custom.sh at $(date)" >> "$LOGFILE"
 # 设置默认防火墙规则，方便虚拟机首次访问 WebUI
 uci set firewall.@zone[1].input='ACCEPT'
 


### PR DESCRIPTION
## Summary
- ensure `glinet/99-custom.sh` initializes the log file variable

## Testing
- `bash -n glinet/99-custom.sh`


------
https://chatgpt.com/codex/tasks/task_e_6847aeb8f030832fb0cc31b750b5ef3c